### PR TITLE
Added initial delay for RC pod startupProbe

### DIFF
--- a/devops/base/server/deploy.yaml
+++ b/devops/base/server/deploy.yaml
@@ -92,8 +92,10 @@ spec:
               path: /api/info
               port: server-port
               scheme: HTTP
-            failureThreshold: 54
+            failureThreshold: 20
             periodSeconds: 10
+            initialDelaySeconds: 30
+            # only putting a delay here since every other probes will run after startupProbe
           livenessProbe:
             httpGet:
               path: /api/info


### PR DESCRIPTION
RC pods take around 30 seconds to get started, so added in an initial delay for the startupProbe, and turned down the threshold a bit in order to give RC pod time to get ready for probing and reduce the failure messages.