### PR TITLE
remove reggie reference from doc

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,1 @@
 *         @ShellyXueHan @jleach
-reggie/*  @ShellyXueHan

--- a/CODE-OF-CONDUCT.md
+++ b/CODE-OF-CONDUCT.md
@@ -1,0 +1,24 @@
+## Contributor Code of Conduct
+
+As contributors and maintainers of this project, and in the interest of fostering an open and welcoming community, we pledge to respect all people who contribute through reporting issues, posting feature requests, updating documentation, submitting pull requests or patches, and other activities.
+
+We are committed to making participation in this project a harassment-free experience for everyone, regardless of level of experience, gender, gender identity and expression, sexual orientation, disability, personal appearance, body size, race, ethnicity, age, religion, or nationality.
+
+Examples of unacceptable behavior by participants include:
+
+- The use of sexualized language or imagery
+- Personal attacks
+- Trolling or insulting/derogatory comments
+- Public or private harassment
+- Publishing other's private information, such as physical or electronic addresses, without explicit permission
+- Other unethical or unprofessional conduct
+
+Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, or to ban temporarily or permanently any contributor for other behaviors that they deem inappropriate, threatening, offensive, or harmful.
+
+By adopting this Code of Conduct, project maintainers commit themselves to fairly and consistently applying these principles to every aspect of managing this project. Project maintainers who do not follow or enforce the Code of Conduct may be permanently removed from the project team.
+
+This Code of Conduct applies both within project spaces and in public spaces when an individual is representing the project or its community.
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting a project maintainer at [Todd.Wilson@gov.bc.ca](mailto:Todd.Wilson@gov.bc.ca). All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances. Maintainers are obligated to maintain confidentiality with regard to the reporter of an incident.
+
+This Code of Conduct is adapted from the Contributor Covenant, version 1.3.0, available at [http://contributor-covenant.org/version/1/3/0/](http://contributor-covenant.org/version/1/3/0/)

--- a/README.md
+++ b/README.md
@@ -1,16 +1,12 @@
 ## TL;DR
 
-The Rocket.Chat application is the primary communication tool for Platform Services and projects using either the [BCDevExchange Lab](https://bcdevexchange.org) or OpenShift Container Platform.. This repo contains all the components for deploying the Rocket.Chat application and its helper application Reggie. See the following documents for more information:
+The Rocket.Chat application is the primary communication tool for Platform Services and projects using either the [BCDevExchange Lab](https://bcdevexchange.org) or OpenShift Container Platform. This repo contains all the components for deploying the Rocket.Chat application. See the following documents for more information:
 
 * [Rocket.Chat](./docs/rocketchat.md); and
-* [Reggie](./docs/reggie.md).
 
 ## Project Structure
 
-Find anything relevant to the project as a whole in the repo root such as OCP4 manifests; docker compose file; and development configuration. Each of the two main components to the project are listed below and have their own build and deployment documentation:
-
-* [Rocket.Chat](./docs/rocketchat.md); and
-* [Reggie](./docs/reggie.md).
+Find anything relevant to the project as a whole in the repo root such as OCP4 manifests; docker compose file; development configuration; build and deployment documentation.
 
 ## Architecture
 
@@ -25,12 +21,11 @@ Additional features and fixes can be found in backlog; find it under issues in t
 
 ## Getting Help or Reporting an Issue
 
-If you find issues with this application suite please create an [issue](https://github.com/bcgov/secure-image-app/issues) describing the problem in detail.
+If you find issues with this application suite please create an issue in this repo describing the problem in detail.
 
 ## How to Contribute
 
-Contributions are welcome. Please ensure they relate to an issue. See our 
-[Code of Conduct](./CODE-OF-CONDUCT.md) that is included with this repo for important details on contributing to Government of British Columbia projects. 
+Contributions are welcome. Please ensure they relate to an issue. See our [Code of Conduct](./CODE-OF-CONDUCT.md) that is included with this repo for important details on contributing to Government of British Columbia projects. 
 
 ## License
 

--- a/devops/readme.md
+++ b/devops/readme.md
@@ -1,10 +1,10 @@
-# DevOps for RocketChat and Reggie
+# DevOps for RocketChat
 
 **Note: This repo is no longer used for managing the Rocketchat deployment**
 
 **Rocketchat has moved to the Gold cluster and uses a separate gitops repo**
 
-**Reggie is still managed in this repo**
+**TODO: Reggie service is retired now, related manifest will be removed from this repo soon**
 
 This RocketChat suite uses Argo CD and Kustomize to manage deployments.  Argo CD is a declarative, GitOps continuous delivery tool for Kubernetes.  Kustomize is a tool for efficiently managing Kubernetes resource manifests for multiple environments.  GitHub Actions constitute the CI portion of the pipeline.
 

--- a/docs/pages/home-page.html
+++ b/docs/pages/home-page.html
@@ -3,9 +3,9 @@
 <h4>User How-Tos:</h4>
 <ul>
   <li>Complete your business information if missing, and upload an avatar.</li>
-  <li>Team members cannot join? <a href="https://reggie.developer.gov.bc.ca" target="_blank">Invite new users</a> or read <a href="https://developer.gov.bc.ca/Steps-to-join-Rocket.Chat" target="_blank">the user guide</a>.</li>
-  <li>iOS issue with too many redirections? Clear cache on safari helps. See <a href="https://support.apple.com/en-us/HT203370">instruction</a>.</li>
-  <li>Seeing Internal Service Error from KeyCloak? Have you tried to clear browser cache and relogin? Still have the problem? Please check if your IDIR account has an email associated with it. If not, either request to update your IDIR account or use an GitHub account to login to RocketChat.</li>  
+  <li>Team members cannot join? <a href="https://just-ask.developer.gov.bc.ca/" target="_blank">Invite new GitHub users</a> or read <a href="https://cloud.gov.bc.ca/private-cloud/support-and-community/stay-connected/steps-to-join-the-bc-gov-rocket-chat/" target="_blank">the user guide</a>.</li>
+  <li>iOS issue with too many redirects? Clear cache on safari helps. See <a href="https://support.apple.com/en-us/HT203370">instruction</a>.</li>
+  <li>Seeing Internal Service Error from KeyCloak? Have you tried to clear browser cache and re-login? Still have the problem? Please check if your IDIR account has an email associated with it. If not, either request to update your IDIR account or use an GitHub account to login to RocketChat.</li>  
 </ul>
 <br>
 <h4>Channel How-Tos:</h4>
@@ -14,7 +14,7 @@
   <li>DevOps platform-related channels will be created and moderated by the DevOps Team Services team. These channels will be prefixed with <code>devops-</code>.</li>
   <li>To create team-specific channels:
     <ul>
-      <li>Please read through the <a href="https://developer.gov.bc.ca/Chat-Channel-Conventions" target="_blank">chat conventions</a>.</li>
+      <li>Please read through the <a href="https://cloud.gov.bc.ca/private-cloud/support-and-community/stay-connected/rocket-chat-channel-descriptions-in-the-bc-gov-private-cloud-paas/" target="_blank">chat conventions</a>.</li>
       <li>Team channel names should be prefixed with <code>&lt;Team Name&gt;-</code>. Please be sure to provide a channel description.</li>
       <li>Please note that channels with confusing or inappropriate names may be renamed by the platform admins.</li>
     </ul>

--- a/docs/pages/login-page.html
+++ b/docs/pages/login-page.html
@@ -6,5 +6,5 @@
       <li>As part of the registration process, you'll be asked to provide your business contact information and verify your email. </li>
       <li>When you come back to Rocket.Chat, please set your user account as <b>firstName.lastName</b>.</li>
     </ul>
-    <p>For Rocket.Chat instructions and community conventions, please see <a href="https://developer.gov.bc.ca/Steps-to-join-Rocket.Chat" target="_blank">this page</a> in DevHub.<p>
+    <p>For Rocket.Chat instructions and community conventions, please see <a href="https://cloud.gov.bc.ca/private-cloud/support-and-community/stay-connected/" target="_blank">this page</a>.<p>
   </div>


### PR DESCRIPTION
### Update:

Reggie has been taken out from Rocketchat's authentication flow. GitHub users will be directed to just-ask if they don't have proper access. This PR is to remove the reggie reference from rocketchat document.